### PR TITLE
add check for number strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ var types = {
     if (s.hasOwnProperty('integer') && s.integer) {
         predicate = and(predicate, util.isInteger);
     }
-    return predicate ? t.subtype(t.Number, predicate) : t.Number;
+    return predicate ? t.subtype(util.Num, predicate) : util.Num;
     },
 
     integer: function (s) {

--- a/src/util.js
+++ b/src/util.js
@@ -6,11 +6,19 @@ function isInteger(n) {
   return n % 1 === 0;
 }
 
-var Null = t.irreducible('Null', function (x) { return x === null; });
-var Int = t.irreducible('Int', isInteger);
+function isNumber(n) {
+	return !isNaN(n) 
+}
 
+var Null = t.irreducible('Null', function (x) {
+  return x === null;
+});
+var Int = t.irreducible('Int', isInteger);
+var Num = t.irreducible('Num', isNumber)
 module.exports = {
   isInteger: isInteger,
+  isNumber: isNumber,
   Null: Null,
-  Int: Int
+  Int: Int,
+  Num: Num
 };


### PR DESCRIPTION
We recently tied mobile builds to our npm library, which means it actually installed the correct version, and likely started catching the issue where number inputs are coming through as strings, ("1000" instead of 1000), and it was failing validation, with an error "Invalid value "200" supplied to /Length". We also see this error when adding hours to labor, since in our schemas those are numbers (most likely to allow decimals like 8.5 hours).

Rainforest errors:
[Broken Length](https://app.rainforestqa.com/runs/555186/tests/167274/browsers/android_phone_71_720_1280/steps/49303106)
[Broken Labor](https://app.rainforestqa.com/runs/555186/tests/167276/browsers/android_phone_71_720_1280/steps/49303096)

We have varied use of the "Number" vs "Integer" in our schemas. My guess is that Integers are expected to always be whole numbers, where Number can be an integer or a float.

Basically adding in a similar util for Number that exists for Integer, but instead of checking if it is a whole number, we just verify the value is a number. I loaded this up locally and it seems to do the trick. I also replaced the library locally for the web app and that also seemed to work fine, but in all fairness the web app is properly passing numbers back, not strings, so likely why we didn't see the issue on the web before now. 