### PR TITLE
Updates to allow listeners in list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhumbix/tcomb-json-schema",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Transform a JSON schema to a tcomb form",
   "main": "dist/index.js",
   "files": [

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -180,6 +180,7 @@ class Listener{
     // Logic functions run by listeners
     evalForm(value, func) {
         if(!value) return null
+        // TODO: can we do something other than eval to protect us from ourselves?
         let output = eval(func)
         return !_.isNil(output) && output.toString()
     }
@@ -191,6 +192,7 @@ class Listener{
         listValue.forEach((listItem, index) => {
             var value = listItem[itemPath[0]]
             var result = null
+            // TODO: can we do something other than eval to protect us from ourselves?
             try{
                 result = eval(func)
             }

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -89,7 +89,7 @@ class Listener{
 
     _updateListComponent(component_value, output) {
         var updatesMade = false
-        if (ccomponent_value && output){
+        if (component_value && output){
             // go through the list and if there is a result and it is diff than the current result - update it
             var updatedValues = component_value.map((item, index) => {
                 var currentItem = Object.assign({}, item)
@@ -131,8 +131,8 @@ class Listener{
             var component = this.formRef.getComponent(componentPath)
             // if any items have been updated this will return a list of all items with updated results
             // if nothing is updated it will return null
-            var updatedList = _updateListComponent(component.state.value, output)
-            if (updatedList){
+            var updatedValues = this._updateListComponent(component.state.value, output)
+            if (updatedValues){
                 component.onChange(updatedValues, componentPath)
             }
         }

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -74,42 +74,51 @@ class Listener{
 
     _fireListenerLogicAndSetState(val, storeSubSection, schema, ui_schema) {
         let output = null;
-        if (val["function"] == "list_adder") {
-            output = this.listNumberAdder(storeSubSection, schema, ui_schema);
-        } else if (val["function"] == "sub_list_adder") {
-            var subListPath = val["sub_list_path"];
-            output = this.subListNumberAdder(storeSubSection, subListPath);
-        } else if (val["function"] == "eval") {
-            output = this.evalForm(storeSubSection, val["eval"]);
-        } else if (val["function"] == "eval_list"){
-            output = this.evalFormList(storeSubSection, val["eval"], val.output_key)
+        let functionName = val["function"]
+        switch(functionName){
+            case "list_adder":
+                output = this.listNumberAdder(storeSubSection, schema, ui_schema)
+                break
+            case "sub_list_adder":
+                var subListPath = val["sub_list_path"];
+                output = this.subListNumberAdder(storeSubSection, subListPath);
+                break
+            case "eval":
+                output = this.evalForm(storeSubSection, val["eval"]);
+                break
+            case "eval_list":
+                output = this.evalFormList(storeSubSection, val["eval"], val.output_key)
+                break
+            default:
+                output = null
         }
         this._updateComponentStateInsideForm(val.output_key, output);
     }
 
-    _updateListComponent(component_value, output) {
-        var updatesMade = false
-        if (component_value && output){
-            // go through the list and if there is a result and it is diff than the current result - update it
-            var updatedValues = component_value.map((item, index) => {
-                var currentItem = Object.assign({}, item)
-                // itemPath is the location within the list item (obj) where 
-                // the field we are updating is - ex. ["Chain Markers", "Length"]
-                var itemPath = output[index]["itemPath"]  
-                var listenerField = itemPath[1]
-                  
-                var listItem = currentItem[itemPath[0]]
-                var currentValue = listItem && listenerField in listItem ? listItem[listenerField] : null
-                // we only want to update the item if the results are different
-                if (output[index]["result"] && currentValue != output[index]["result"]){
-                    updatesMade = true
-                    var result = output[index]["result"]
-                    currentItem[itemPath[0]][itemPath[1]] = result
-                    return currentItem
-                }
-                return currentItem
-            })
+    _updateListComponent(componentValue, output) {
+        if (!componentValue || !output){
+            return null
         }
+        let updatesMade = false
+        // go through the list and if there is a result and it is diff than the current result - update it
+        const updatedValues = componentValue.map((item, index) => {
+            let currentItem = Object.assign({}, item)
+            // itemPath is the location within the list item (obj) where 
+            // the field we are updating is - ex. ["Chain Markers", "Length"]
+            const itemPath = output[index]["itemPath"]  
+            const listenerField = itemPath[1]
+              
+            const listItem = currentItem[itemPath[0]]
+            const currentValue = listItem && listenerField in listItem ? listItem[listenerField] : null
+            // we only want to update the item if the results are different
+            if (output[index]["result"] && currentValue != output[index]["result"]){
+                updatesMade = true
+                const result = output[index]["result"]
+                currentItem[itemPath[0]][itemPath[1]] = result
+                return currentItem
+            }
+            return currentItem
+        })
         // if any updates are made - update the list component with the new values
         if (updatesMade){
             return updatedValues
@@ -118,7 +127,7 @@ class Listener{
     }
 
     _updateComponentStateInsideForm(outputKey, output) {
-        var path = outputKey.replace(/\//g, '.').substr(1);
+        const path = outputKey.replace(/\//g, '.').substr(1);
         if (outputKey.includes("-")){ // indicates it is coming from a list
             /* Because we don't have the specific index of what list item is being edited
                we can't get the component because we don't have the full path to the field nested in the list
@@ -127,17 +136,17 @@ class Listener{
                TODO: We need to come up with a more scalable plan that is more flexible */
 
             // get the root list component that holds the list values
-            var componentPath = path.slice(0, outputKey.indexOf(this.listIndexPlaceholder) - 1)
-            var component = this.formRef.getComponent(componentPath)
+            const componentPath = path.slice(0, outputKey.indexOf(this.listIndexPlaceholder) - 1)
+            const component = this.formRef.getComponent(componentPath)
             // if any items have been updated this will return a list of all items with updated results
             // if nothing is updated it will return null
-            var updatedValues = this._updateListComponent(component.state.value, output)
+            const updatedValues = this._updateListComponent(component.state.value, output)
             if (updatedValues){
                 component.onChange(updatedValues, componentPath)
             }
         }
         else{
-            var component = this.formRef.getComponent(path);
+            const component = this.formRef.getComponent(path);
             if (output && output != component.state.value) {
                 component.onChange(output);
             }
@@ -179,7 +188,7 @@ class Listener{
         if (!listValue) return null;
         var output = []
         var itemPath = outputKey.slice(outputKey.indexOf(this.listIndexPlaceholder) + this.listIndexPlaceholder.length).split("/")
-        _.each(listValue, function(listItem, index) {
+        listValue.forEach((listItem, index) => {
             var value = listItem[itemPath[0]]
             var result = null
             try{


### PR DESCRIPTION
Issue: WMATA has requested a listener field within a list item for their Chain Markers/Length field. 

Unfortunately we are on a very tight deadline to get this delivered to WMATA. This solution is not particularly flexible, and would only currently work for how we have WMATA data set up, but for the moment it should work. Because it is mostly adding in a new eval method, no other schema functionality should be impacted. 

Changes made:
- Updated the _getListenersFromUISchema method to check list item fields for listeners.
- Added new eval_list method that will take in the value of a list component (the whole list), go through the items in that list, and returns a list of objects with results and the itemPath for that field within the list item.
- We then parse the results, and check if any results are different that the existing result. Only update the component If there are updated values.
