### PR TITLE
Adding the ability to register Number and Integer as types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhumbix/tcomb-json-schema",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Transform a JSON schema to a tcomb form",
   "main": "dist/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,9 @@ var types = {
     },
 
     number: function (s) {
+    if (registerTypes.hasOwnProperty("number")) {
+        return registerTypes["number"]
+    }
     var predicate;
     if (s.hasOwnProperty('minimum')) {
         predicate = s.exclusiveMinimum ?
@@ -74,6 +77,9 @@ var types = {
     },
 
     integer: function (s) {
+    if(registerTypes.hasOwnProperty('integer')){
+        return registerTypes['integer']
+    }
     var predicate;
     if (s.hasOwnProperty('minimum')) {
         predicate = s.exclusiveMinimum ?


### PR DESCRIPTION
We need this so that we can use `transform.registerType` for `number` and `integer` types in tcomb. This way we won't have to make a component that will need to be referenced in the ui_schema like `employee-selector` or `date-picker` the use of `{"type": "number"}` in the schema will be all we need.

Classic Kyle added similar code so we could do this for booleans.